### PR TITLE
7주차 과제 제출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/
 *.iws
 *.iml
 *.ipr

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,12 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="assignment" uuid="93d126fc-dc39-41fa-bfae-2b0135ddd792">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="@localhost" uuid="c382e89c-d4e3-43d4-914e-47e121674315">
-      <driver-ref>mysql.8</driver-ref>
-      <synchronize>true</synchronize>
-      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://localhost:3306</jdbc-url>
-      <jdbc-additional-properties>
-        <property name="com.intellij.clouds.kubernetes.db.host.port" />
-        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
-        <property name="com.intellij.clouds.kubernetes.db.container.port" />
-      </jdbc-additional-properties>
-      <working-dir>$ProjectFileDir$</working-dir>
-    </data-source>
     <data-source source="LOCAL" name="assignment" uuid="93d126fc-dc39-41fa-bfae-2b0135ddd792">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>

--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/c382e89c-d4e3-43d4-914e-47e121674315/console.sql" value="c382e89c-d4e3-43d4-914e-47e121674315" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ repositories {
     mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,4 +40,8 @@ dependencies {
 
     // jwt 의존성
     implementation 'com.auth0:java-jwt:4.4.0'
+
+    // Redis 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // validation 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.4'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'
@@ -25,7 +25,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     // lombok 의존성 추가

--- a/src/main/java/org/sopt/article/controller/ArticleController.java
+++ b/src/main/java/org/sopt/article/controller/ArticleController.java
@@ -1,7 +1,6 @@
 package org.sopt.article.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,12 +15,7 @@ import org.sopt.global.config.swagger.SwaggerResponseDescription;
 import org.sopt.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/article/dto/response/ArticleListCommentCountResponse.java
+++ b/src/main/java/org/sopt/article/dto/response/ArticleListCommentCountResponse.java
@@ -1,0 +1,48 @@
+package org.sopt.article.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.article.entity.Article;
+import org.sopt.article.entity.Tag;
+
+import java.time.LocalDate;
+
+public record ArticleListCommentCountResponse(
+
+        @Schema(description = "아티클 ID", example = "1")
+        Long id,
+
+        @Schema(description = "아티클 제목", example = "집에 빨리 가는 법")
+        String title,
+
+        @Schema(description = "아티클 내용",example = "날아간다")
+        String content,
+
+        @Schema(description = "태그", example = "CS")
+        Tag tag,
+
+        @Schema(description = "날짜", example = "2025-11-26")
+        LocalDate date,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "작성자 이름", example = "조효동")
+        String memberName,
+
+        @Schema(description = "댓글 개수", example = "30")
+        int commentCount
+) {
+    public static ArticleListCommentCountResponse from(Article article) {
+
+        return new ArticleListCommentCountResponse(
+                article.getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getTag(),
+                article.getDate(),
+                article.getMember().getId(),
+                article.getMember().getName(),
+                article.getComments().size()
+        );
+    }
+}

--- a/src/main/java/org/sopt/article/dto/response/ArticleListResponse.java
+++ b/src/main/java/org/sopt/article/dto/response/ArticleListResponse.java
@@ -4,11 +4,11 @@ import org.sopt.article.entity.Article;
 
 import java.util.List;
 
-public record ArticleListResponse(List<ArticleResponse> articles) {
+public record ArticleListResponse(List<ArticleListCommentCountResponse> articles) {
 
     public static ArticleListResponse from(List<Article> articles) {
-        List<ArticleResponse> articleResponses = articles.stream()
-                .map(ArticleResponse::from)
+        List<ArticleListCommentCountResponse> articleResponses = articles.stream()
+                .map(ArticleListCommentCountResponse::from)
                 .toList();
 
         return new ArticleListResponse(articleResponses);

--- a/src/main/java/org/sopt/article/dto/response/ArticleResponse.java
+++ b/src/main/java/org/sopt/article/dto/response/ArticleResponse.java
@@ -3,8 +3,10 @@ package org.sopt.article.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.sopt.article.entity.Article;
 import org.sopt.article.entity.Tag;
+import org.sopt.comment.dto.response.CommentResponse;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record ArticleResponse(
 
@@ -27,9 +29,17 @@ public record ArticleResponse(
         Long memberId,
 
         @Schema(description = "작성자 이름", example = "조효동")
-        String memberName
+        String memberName,
+
+        @Schema(description = "댓글 목록", example = "1등")
+        List<CommentResponse> comments
 ) {
     public static ArticleResponse from(Article article) {
+
+        List<CommentResponse> comments = article.getComments().stream()
+                .map(CommentResponse::from)
+                .toList();
+
         return new ArticleResponse(
                 article.getId(),
                 article.getTitle(),
@@ -37,7 +47,8 @@ public record ArticleResponse(
                 article.getTag(),
                 article.getDate(),
                 article.getMember().getId(),
-                article.getMember().getName()
+                article.getMember().getName(),
+                comments
         );
     }
 }

--- a/src/main/java/org/sopt/article/entity/Article.java
+++ b/src/main/java/org/sopt/article/entity/Article.java
@@ -39,6 +39,7 @@ public class Article {
     private Member member;
 
     @OneToMany(mappedBy = "article")
+    @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
     public static Article create(String title,String content,LocalDate date,Tag tag,Member member) {

--- a/src/main/java/org/sopt/article/entity/Article.java
+++ b/src/main/java/org/sopt/article/entity/Article.java
@@ -5,9 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.comment.entity.Comment;
 import org.sopt.member.entity.Member;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +37,9 @@ public class Article {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "article")
+    private List<Comment> comments = new ArrayList<>();
 
     public static Article create(String title,String content,LocalDate date,Tag tag,Member member) {
         Article article = Article.builder()

--- a/src/main/java/org/sopt/article/repository/ArticleRepository.java
+++ b/src/main/java/org/sopt/article/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package org.sopt.article.repository;
 
 import org.sopt.article.entity.Article;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/org/sopt/article/service/ArticleService.java
+++ b/src/main/java/org/sopt/article/service/ArticleService.java
@@ -1,6 +1,7 @@
 package org.sopt.article.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.article.dto.request.ArticleCreateRequest;
 import org.sopt.article.dto.response.ArticleListResponse;
 import org.sopt.article.dto.response.ArticleResponse;
@@ -12,12 +13,15 @@ import org.sopt.member.entity.Member;
 import org.sopt.member.exception.MemberErrorCode;
 import org.sopt.member.exception.MemberException;
 import org.sopt.member.repository.MemberRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,6 +30,7 @@ public class ArticleService  {
     private final MemberRepository memberRepository;
 
     @Transactional
+    @CacheEvict(value = "articleList", key="'all'")
     public ArticleResponse createArticle(Long memberId, ArticleCreateRequest request) {
 
         validateTitleExists(request.title());
@@ -41,7 +46,11 @@ public class ArticleService  {
 
     }
 
+    // 아티클 상세조회 (댓글 포함) 캐싱
+    @Cacheable(value = "articleDetail", key = "#articleId")
     public ArticleResponse findArticle(Long articleId) {
+
+        log.info(">>>> [Cache Miss - DB Access] findArticle method executed for articleId: {}", articleId);
 
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
@@ -50,6 +59,8 @@ public class ArticleService  {
 
     }
 
+    // 아티클 전체 조회 (댓글 개수만) 캐싱
+    @Cacheable(value = "articleList", key = "'all'")
     public ArticleListResponse findAllArticles() {
 
         List<Article> articles = articleRepository.findAll();

--- a/src/main/java/org/sopt/article/service/ArticleService.java
+++ b/src/main/java/org/sopt/article/service/ArticleService.java
@@ -50,7 +50,7 @@ public class ArticleService  {
     @Cacheable(value = "articleDetail", key = "#articleId")
     public ArticleResponse findArticle(Long articleId) {
 
-        log.info(">>>> [Cache Miss - DB Access] findArticle method executed for articleId: {}", articleId);
+        log.info("[CACHE MISS] DB 조회 아티클 ID: {}", articleId);
 
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
@@ -62,6 +62,8 @@ public class ArticleService  {
     // 아티클 전체 조회 (댓글 개수만) 캐싱
     @Cacheable(value = "articleList", key = "'all'")
     public ArticleListResponse findAllArticles() {
+
+        log.info("[CACHE MISS] DB 조회 - 전체 아티클 목록");
 
         List<Article> articles = articleRepository.findAll();
 

--- a/src/main/java/org/sopt/comment/controller/CommentController.java
+++ b/src/main/java/org/sopt/comment/controller/CommentController.java
@@ -3,8 +3,10 @@ package org.sopt.comment.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.comment.dto.request.CommentCreateRequest;
+import org.sopt.comment.dto.request.CommentUpdateRequest;
 import org.sopt.comment.dto.response.CommentListResponse;
 import org.sopt.comment.dto.response.CommentResponse;
 import org.sopt.comment.service.CommentService;
@@ -17,7 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/comment")
+@RequestMapping("/articles")
 @RequiredArgsConstructor
 @Tag(name = "댓글", description = "댓글 작성 / 조회 등 관리 API")
 public class CommentController {
@@ -25,21 +27,46 @@ public class CommentController {
     private final CommentService commentService;
 
     @Operation(summary = "댓글 작성", description = "로그인한 회원이 아티클에 댓글을 작성합니다")
-    @PostMapping("/{articleId}")
+    @PostMapping("/{articleId}/comments")
     @BusinessExceptionDescription(SwaggerResponseDescription.CREATE_COMMENT)
     @SecurityRequirement(name = "JWT")
     public ResponseEntity<ApiResponse<CommentResponse>> createComment(@LoginMemberId Long memberId,
                                                                           @PathVariable Long articleId,
-                                                                          CommentCreateRequest request) {
+                                                                          @Valid @RequestBody CommentCreateRequest request) {
         CommentResponse response = commentService.createComment(memberId,articleId,request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     @Operation(summary = "댓글 조회", description = "특정 아티클의 댓글을 조회합니다.")
-    @GetMapping("{articleId}")
+    @GetMapping("/{articleId}/comments")
     @BusinessExceptionDescription(SwaggerResponseDescription.GET_COMMENT)
     public ResponseEntity<ApiResponse<CommentListResponse>> findComment(@PathVariable Long articleId) {
         CommentListResponse responses = commentService.findComment(articleId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
+    }
+
+    @Operation(summary = "댓글 수정", description = "특정 아티클의 댓글을 수정합니다.")
+    @PatchMapping("/{articleId}/comments/{commentId}")
+    @SecurityRequirement(name = "JWT")
+    @BusinessExceptionDescription(SwaggerResponseDescription.UPDATE_COMMENT)
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(@LoginMemberId Long memberId,
+                                                                      @PathVariable Long articleId,
+                                                                      @PathVariable Long commentId,
+                                                                      @Valid @RequestBody CommentUpdateRequest request
+                                                                      ){
+        CommentResponse response = commentService.updateComment(memberId,articleId,commentId,request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "특정 아티클의 댓글을 삭제합니다.")
+    @DeleteMapping("/{articleId}/comments/{commentId}")
+    @SecurityRequirement(name = "JWT")
+    @BusinessExceptionDescription(SwaggerResponseDescription.DELETE_COMMENT)
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@LoginMemberId Long memberId,
+                                                           @PathVariable Long articleId,
+                                                            @PathVariable Long commentId) {
+        commentService.deleteComment(memberId,articleId,commentId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
     }
 }

--- a/src/main/java/org/sopt/comment/controller/CommentController.java
+++ b/src/main/java/org/sopt/comment/controller/CommentController.java
@@ -1,9 +1,45 @@
 package org.sopt.comment.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sopt.comment.dto.request.CommentCreateRequest;
+import org.sopt.comment.dto.response.CommentListResponse;
+import org.sopt.comment.dto.response.CommentResponse;
+import org.sopt.comment.service.CommentService;
+import org.sopt.global.annotation.BusinessExceptionDescription;
+import org.sopt.global.annotation.LoginMemberId;
+import org.sopt.global.config.swagger.SwaggerResponseDescription;
+import org.sopt.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/comment")
+@RequiredArgsConstructor
+@Tag(name = "댓글", description = "댓글 작성 / 조회 등 관리 API")
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 작성", description = "로그인한 회원이 아티클에 댓글을 작성합니다")
+    @PostMapping("/{articleId}")
+    @BusinessExceptionDescription(SwaggerResponseDescription.CREATE_COMMENT)
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(@LoginMemberId Long memberId,
+                                                                          @PathVariable Long articleId,
+                                                                          CommentCreateRequest request) {
+        CommentResponse response = commentService.createComment(memberId,articleId,request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "댓글 조회", description = "특정 아티클의 댓글을 조회합니다.")
+    @GetMapping("{articleId}")
+    @BusinessExceptionDescription(SwaggerResponseDescription.GET_COMMENT)
+    public ResponseEntity<ApiResponse<CommentListResponse>> findComment(@PathVariable Long articleId) {
+        CommentListResponse responses = commentService.findComment(articleId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
+    }
 }

--- a/src/main/java/org/sopt/comment/controller/CommentController.java
+++ b/src/main/java/org/sopt/comment/controller/CommentController.java
@@ -1,0 +1,9 @@
+package org.sopt.comment.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/comment")
+public class CommentController {
+}

--- a/src/main/java/org/sopt/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/comment/dto/request/CommentCreateRequest.java
@@ -1,10 +1,12 @@
 package org.sopt.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
 
         @NotBlank(message = "내용을 빈칸으로 둘 수 없습니다.")
+        @Size(max = 300, message = "댓글은 300자를 초과할 수 없습니다.")
         String content
 
 ) {

--- a/src/main/java/org/sopt/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,11 @@
+package org.sopt.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentCreateRequest(
+
+        @NotBlank(message = "내용을 빈칸으로 둘 수 없습니다.")
+        String content
+
+) {
+}

--- a/src/main/java/org/sopt/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/org/sopt/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,13 @@
+package org.sopt.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 300, message = "댓글은 300자를 초과할 수 없습니다.")
+        String content
+
+) {
+}

--- a/src/main/java/org/sopt/comment/dto/response/CommentListResponse.java
+++ b/src/main/java/org/sopt/comment/dto/response/CommentListResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.comment.dto.response;
+
+import org.sopt.comment.entity.Comment;
+
+import java.util.List;
+
+public record CommentListResponse(List<CommentResponse> comments) {
+
+    public static CommentListResponse from(List<Comment> comments){
+        List<CommentResponse> commentResponses = comments.stream().
+                map(CommentResponse::from)
+                .toList();
+
+        return new CommentListResponse(commentResponses);
+    }
+}

--- a/src/main/java/org/sopt/comment/dto/response/CommentListResponse.java
+++ b/src/main/java/org/sopt/comment/dto/response/CommentListResponse.java
@@ -13,4 +13,6 @@ public record CommentListResponse(List<CommentResponse> comments) {
 
         return new CommentListResponse(commentResponses);
     }
+
+
 }

--- a/src/main/java/org/sopt/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/sopt/comment/dto/response/CommentResponse.java
@@ -10,9 +10,6 @@ public record CommentResponse(
         // 댓글 내용
         String content,
 
-        // 댓글 단 아티클 제목
-        String articleTitle,
-
         // 댓글 작성자 멤버 id
         Long memberId,
 
@@ -24,7 +21,6 @@ public record CommentResponse(
         return new CommentResponse(
                 comment.getId(),
                 comment.getContent(),
-                comment.getArticle().getTitle(),
                 comment.getMember().getId(),
                 comment.getMember().getName()
         );

--- a/src/main/java/org/sopt/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/sopt/comment/dto/response/CommentResponse.java
@@ -1,0 +1,32 @@
+package org.sopt.comment.dto.response;
+
+import org.sopt.comment.entity.Comment;
+
+public record CommentResponse(
+
+        // 댓글 아이디
+        Long id,
+
+        // 댓글 내용
+        String content,
+
+        // 댓글 단 아티클 제목
+        String articleTitle,
+
+        // 댓글 작성자 멤버 id
+        Long memberId,
+
+        // 댓글 작성자 멤버 이름
+        String memberName
+) {
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getContent(),
+                comment.getArticle().getTitle(),
+                comment.getMember().getId(),
+                comment.getMember().getName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/comment/entity/Comment.java
@@ -41,4 +41,8 @@ public class Comment {
 
         return comment;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/org/sopt/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/comment/entity/Comment.java
@@ -2,17 +2,14 @@ package org.sopt.comment.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.sopt.article.entity.Article;
 import org.sopt.member.entity.Member;
 
 @Entity
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Comment {
 
@@ -31,4 +28,17 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public static Comment create(String content, Article article, Member member) {
+        Comment comment = Comment.builder()
+                .content(content)
+                .article(article)
+                .member(member)
+                .build();
+
+        article.getComments().add(comment);
+        member.getComments().add(comment);
+
+        return comment;
+    }
 }

--- a/src/main/java/org/sopt/comment/entity/Comment.java
+++ b/src/main/java/org/sopt/comment/entity/Comment.java
@@ -1,0 +1,34 @@
+package org.sopt.comment.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.article.entity.Article;
+import org.sopt.member.entity.Member;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(length = 300)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/org/sopt/comment/exception/CommentErrorCode.java
+++ b/src/main/java/org/sopt/comment/exception/CommentErrorCode.java
@@ -1,0 +1,30 @@
+package org.sopt.comment.exception;
+
+import org.sopt.global.exception.errorcode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum CommentErrorCode implements ErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"C001","해당 댓글을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    CommentErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/comment/exception/CommentErrorCode.java
+++ b/src/main/java/org/sopt/comment/exception/CommentErrorCode.java
@@ -4,7 +4,9 @@ import org.sopt.global.exception.errorcode.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum CommentErrorCode implements ErrorCode {
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"C001","해당 댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"C001","해당 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_MATCH_ARTICLE(HttpStatus.NOT_FOUND,"C002","해당 아티클의 댓글이 아닙니다."),
+    NOT_COMMENT_OWNER(HttpStatus.NOT_FOUND,"C003","해당 아티클의 작성자가 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/sopt/comment/exception/CommentException.java
+++ b/src/main/java/org/sopt/comment/exception/CommentException.java
@@ -1,0 +1,10 @@
+package org.sopt.comment.exception;
+
+import org.sopt.global.exception.BusinessException;
+import org.sopt.global.exception.errorcode.ErrorCode;
+
+public class CommentException extends BusinessException {
+    public CommentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/sopt/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.comment.repository;
+
+import org.sopt.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+}

--- a/src/main/java/org/sopt/comment/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/comment/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package org.sopt.comment.repository;
 import org.sopt.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment,Long> {
+    List<Comment> findByArticleId(Long articleId);
 }

--- a/src/main/java/org/sopt/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/comment/service/CommentService.java
@@ -1,0 +1,4 @@
+package org.sopt.comment.service;
+
+public class CommentService {
+}

--- a/src/main/java/org/sopt/comment/service/CommentService.java
+++ b/src/main/java/org/sopt/comment/service/CommentService.java
@@ -1,4 +1,55 @@
 package org.sopt.comment.service;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.article.entity.Article;
+import org.sopt.article.exception.ArticleErrorCode;
+import org.sopt.article.exception.ArticleException;
+import org.sopt.article.repository.ArticleRepository;
+import org.sopt.comment.dto.request.CommentCreateRequest;
+import org.sopt.comment.dto.response.CommentListResponse;
+import org.sopt.comment.dto.response.CommentResponse;
+import org.sopt.comment.entity.Comment;
+import org.sopt.comment.repository.CommentRepository;
+import org.sopt.member.entity.Member;
+import org.sopt.member.exception.MemberErrorCode;
+import org.sopt.member.exception.MemberException;
+import org.sopt.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
 public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final ArticleRepository articleRepository;
+
+    public CommentResponse createComment(Long memberId, Long articleId, CommentCreateRequest request) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
+
+        Comment comment = Comment.create(request.content(),article,member);
+
+        Comment savedComment = commentRepository.save(comment);
+
+        return CommentResponse.from(savedComment);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentListResponse findComment(Long articleId){
+
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByArticleId(articleId);
+
+        return CommentListResponse.from(comments);
+    }
 }

--- a/src/main/java/org/sopt/global/config/redis/CacheTtlProperties.java
+++ b/src/main/java/org/sopt/global/config/redis/CacheTtlProperties.java
@@ -1,0 +1,14 @@
+package org.sopt.global.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cache.ttl")
+public record CacheTtlProperties(
+
+        long defaultTtl,
+
+        long articleDetail,
+
+        long articleList
+) {
+}

--- a/src/main/java/org/sopt/global/config/redis/RedisConfig.java
+++ b/src/main/java/org/sopt/global/config/redis/RedisConfig.java
@@ -1,0 +1,93 @@
+package org.sopt.global.config.redis;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final CacheTtlProperties cacheTtlProperties;
+
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+
+        BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return mapper;
+    }
+
+    @Bean
+    public RedisSerializer<Object> redisSerializer(ObjectMapper redisObjectMapper) {
+        // JSON 형식으로 직렬화
+        return new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+    }
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration(RedisSerializer<Object> redisSerializer) {
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                // key -> String으로 저장
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new StringRedisSerializer())
+                )
+                // value -> JSON으로 저장
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(redisSerializer)
+                )
+                // null값 -> 캐싱x
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMillis(cacheTtlProperties.defaultTtl()));
+    }
+
+    @Bean
+    public CacheManager cacheManager(
+            RedisConnectionFactory redisConnectionFactory,
+            RedisCacheConfiguration redisCacheConfiguration){
+
+        // 캐시별 설정을 담는 Map
+        Map<String,RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        // articleDetail 캐시
+        cacheConfigurations.put("articleDetail", redisCacheConfiguration.entryTtl(Duration.ofMillis(cacheTtlProperties.articleDetail())));
+
+        cacheConfigurations.put("articleList",redisCacheConfiguration.entryTtl(Duration.ofMillis(cacheTtlProperties.articleList())));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/global/config/redis/RedisConfig.java
+++ b/src/main/java/org/sopt/global/config/redis/RedisConfig.java
@@ -39,7 +39,7 @@ public class RedisConfig {
         BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
                 .allowIfBaseType(Object.class)
                 .build();
-        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING);
 
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/org/sopt/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_PATH).permitAll()
-                        .requestMatchers(HttpMethod.GET,"/comment/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/articles/{articleId}/comments").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/sopt/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.global.jwt.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -34,6 +35,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_PATH).permitAll()
+                        .requestMatchers(HttpMethod.GET,"/comment/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/sopt/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/security/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private static final String[] ALLOWED_PATH={
-            "/auth/**","/members/**","/articles/all","/articles/{id}","/articles/search",
+            "/auth/**","/members/**","/articles/all","/articles/**","/articles/search",
             "/swagger-ui/**","/v3/api-docs/**","/*.html", "/static/**", "/css/**", "/js/**"
     };
 

--- a/src/main/java/org/sopt/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/security/SecurityConfig.java
@@ -24,8 +24,17 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private static final String[] ALLOWED_PATH={
-            "/auth/**","/members/**","/articles/all","/articles/**","/articles/search",
-            "/swagger-ui/**","/v3/api-docs/**","/*.html", "/static/**", "/css/**", "/js/**"
+            "/auth/**",
+            "/members/**",
+
+            "/articles/all",
+            "/articles/**",
+            "/articles/search",
+
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+
+            "/*.html", "/static/**", "/css/**", "/js/**"
     };
 
     @Bean

--- a/src/main/java/org/sopt/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
-    private static final String[] ALLOWED_PATH={
+    private static final String[] ALLOWED_PATH = {
             "/auth/**",
             "/members/**",
 

--- a/src/main/java/org/sopt/global/config/swagger/ExampleHolder.java
+++ b/src/main/java/org/sopt/global/config/swagger/ExampleHolder.java
@@ -1,4 +1,4 @@
-package org.sopt.__sopkathon.global.config.swagger;
+package org.sopt.global.config.swagger;
 
 import io.swagger.v3.oas.models.examples.Example;
 import lombok.Builder;

--- a/src/main/java/org/sopt/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt/global/config/swagger/SwaggerConfig.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.sopt.global.annotation.BusinessExceptionDescription;
 import org.sopt.global.exception.errorcode.ErrorCode;
@@ -81,18 +80,18 @@ public class SwaggerConfig {
         Set<ErrorCode> errorCodeList = type.getErrorCodeList();
 
         // 3. 각 에러 코드 ExampleHolder로 변환 및 HTTP 상태별 그룹핑
-        Map<Integer, List<org.sopt.__sopkathon.global.config.swagger.ExampleHolder>> statusWithExampleHolders =
+        Map<Integer, List<org.sopt.global.config.swagger.ExampleHolder>> statusWithExampleHolders =
                 errorCodeList.stream()
                         .map(
                                 errorCode -> {
-                                    return org.sopt.__sopkathon.global.config.swagger.ExampleHolder.builder()
+                                    return org.sopt.global.config.swagger.ExampleHolder.builder()
                                             .holder(
                                                     getSwaggerExample(errorCode)) // ErrorCode -> Swagger Example
                                             .code(errorCode.getStatus().value()) // 404
                                             .name(errorCode.toString()) // M001
                                             .build();
                                 }
-                        ).collect(groupingBy(org.sopt.__sopkathon.global.config.swagger.ExampleHolder::getCode));
+                        ).collect(groupingBy(org.sopt.global.config.swagger.ExampleHolder::getCode));
 
         // 4. 스웨거에 추가
         addExamplesToResponses(responses, statusWithExampleHolders);
@@ -125,7 +124,7 @@ public class SwaggerConfig {
     // Swagger에 Example 추가
     private void addExamplesToResponses(
             ApiResponses responses,
-            Map<Integer, List<org.sopt.__sopkathon.global.config.swagger.ExampleHolder>> statusWithExampleHolders) {
+            Map<Integer, List<org.sopt.global.config.swagger.ExampleHolder>> statusWithExampleHolders) {
 
         // HTTP 상태 코드별 처리
         statusWithExampleHolders.forEach(

--- a/src/main/java/org/sopt/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/global/config/swagger/SwaggerResponseDescription.java
@@ -3,11 +3,13 @@ package org.sopt.global.config.swagger;
 import lombok.Getter;
 import org.sopt.article.exception.ArticleErrorCode;
 import org.sopt.auth.exception.AuthErrorCode;
+import org.sopt.comment.exception.CommentErrorCode;
 import org.sopt.global.exception.errorcode.ErrorCode;
 import org.sopt.global.exception.errorcode.GlobalErrorCode;
 import org.sopt.member.exception.MemberErrorCode;
 
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 @Getter
@@ -38,6 +40,16 @@ public enum SwaggerResponseDescription {
 
     REQUEST_LOGIN(new LinkedHashSet<>(Set.of(
             AuthErrorCode.INVALID_PASSWORD
+    ))),
+
+    CREATE_COMMENT(new LinkedHashSet<>(Set.of(
+            MemberErrorCode.MEMBER_NOT_FOUND,
+            ArticleErrorCode.ARTICLE_NOT_FOUND,
+            CommentErrorCode.COMMENT_NOT_FOUND
+    ))),
+
+    GET_COMMENT(new LinkedHashSet<>(Set.of(
+            ArticleErrorCode.ARTICLE_NOT_FOUND
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/global/config/swagger/SwaggerResponseDescription.java
@@ -3,6 +3,7 @@ package org.sopt.global.config.swagger;
 import lombok.Getter;
 import org.sopt.article.exception.ArticleErrorCode;
 import org.sopt.auth.exception.AuthErrorCode;
+import org.sopt.comment.entity.Comment;
 import org.sopt.comment.exception.CommentErrorCode;
 import org.sopt.global.exception.errorcode.ErrorCode;
 import org.sopt.global.exception.errorcode.GlobalErrorCode;
@@ -50,6 +51,18 @@ public enum SwaggerResponseDescription {
 
     GET_COMMENT(new LinkedHashSet<>(Set.of(
             ArticleErrorCode.ARTICLE_NOT_FOUND
+    ))),
+
+    UPDATE_COMMENT(new LinkedHashSet<>(Set.of(
+             CommentErrorCode.COMMENT_NOT_FOUND,
+             CommentErrorCode.COMMENT_NOT_MATCH_ARTICLE,
+             CommentErrorCode.NOT_COMMENT_OWNER
+    ))),
+
+    DELETE_COMMENT(new LinkedHashSet<>(Set.of(
+            CommentErrorCode.COMMENT_NOT_FOUND,
+            CommentErrorCode.COMMENT_NOT_MATCH_ARTICLE,
+            CommentErrorCode.NOT_COMMENT_OWNER
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/global/exception/errorcode/GlobalErrorCode.java
@@ -11,7 +11,7 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "J002", "유효하지 않은 액세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "J003", "유효하지 않은 리프레쉬 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "J004", "만료된 토큰입니다."),
-    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "J005", "토큰이 비어있습니다."),
+    EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "J005", "토큰이 비어있습니다. 로그인이 필요합니다."),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN,"J006","접근 권한이 없습니다.");
     ;
 

--- a/src/main/java/org/sopt/member/entity/Member.java
+++ b/src/main/java/org/sopt/member/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.article.entity.Article;
+import org.sopt.comment.entity.Comment;
 import org.sopt.member.exception.MemberException;
 import org.sopt.member.exception.MemberErrorCode;
 
@@ -48,6 +49,9 @@ public class Member {
 
     @Column(name = "provider_id")
     private String providerId; // 카카오 회원번호를 위한 필드
+
+    @OneToMany(mappedBy = "member")
+    private List<Comment> comments = new ArrayList<>();
 
 
     public static Member create(String name, String birth, String email, Gender gender, String password) {

--- a/src/main/java/org/sopt/member/entity/Member.java
+++ b/src/main/java/org/sopt/member/entity/Member.java
@@ -39,6 +39,7 @@ public class Member {
     private Gender gender;
 
     @OneToMany(mappedBy = "member")
+    @Builder.Default
     private List<Article> articles = new ArrayList<>();
 
     @Column(nullable = true)
@@ -51,6 +52,7 @@ public class Member {
     private String providerId; // 카카오 회원번호를 위한 필드
 
     @OneToMany(mappedBy = "member")
+    @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://localhost:3306/assignment
-    username: hyodongg
-    password: ejvhqkel12!@
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -13,6 +13,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        default_batch_fetch_size: 100
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
     show-sql: true
@@ -39,8 +40,6 @@ logging:
     org.springframework.cache: TRACE
     org.springframework.cache.interceptor.CacheInterceptor: TRACE
 
-
-
 security:
   jwt:
     secret: ${JWT_SECRET}
@@ -51,13 +50,8 @@ security:
     redirectUri: ${KAKAO_REDIRECT_URI}
 
 springdoc:
-  default-consumes-media-type: application/json
-  default-produces-media-type: application/json
-  api-docs:
-    path: /v3/api-docs # API 명세서 JSON 경로 설정
   swagger-ui:
-    path: /swagger-ui # Swagger UI 접속 경로 (localhost:8080/swagger-ui)
-    url: /v3/api-docs # ⭐️ 가장 중요! Swagger에게 읽어올 문서 위치를 강제로 지정
-    disable-swagger-default-url: true # 기본 Petstore URL 비활성화
-    operations-sorter: method # API 목록을 HTTP Method 순서로 정렬
-    display-request-duration: true # 요청 보냈을 때 걸린 시간 표시 (디버깅용)
+    url: /v3/api-docs
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,29 @@ spring:
         format_sql: true
     show-sql: true
 
+  # Redis 설정
+  data:
+    redis:
+      host: ${REDIS_HOST} # Redis 서버 주소
+      port: ${REDIS_PORT} # Redis 포트
+      password: ${REDIS_PASSWORD}
+
+  # 캐시 설정
+  cache:
+    type: redis # 캐시 구현체로 Redis 사용
+
+cache:
+  ttl:
+    default-ttl: ${CACHE_TTL_DEFAULT:600000}
+    article-detail: ${CACHE_TTL_ARTICLE_DETAIL}
+    article-list: ${CACHE_TTL_ARTICLE_LIST}
+
+logging:
+  level:
+    org.springframework.cache: TRACE
+    org.springframework.cache.interceptor.CacheInterceptor: TRACE
+
+
 
 security:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,15 @@ security:
   kakao:
     restApiKey: ${KAKAO_REST_API_KEY}
     redirectUri: ${KAKAO_REDIRECT_URI}
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  api-docs:
+    path: /v3/api-docs # API 명세서 JSON 경로 설정
+  swagger-ui:
+    path: /swagger-ui # Swagger UI 접속 경로 (localhost:8080/swagger-ui)
+    url: /v3/api-docs # ⭐️ 가장 중요! Swagger에게 읽어올 문서 위치를 강제로 지정
+    disable-swagger-default-url: true # 기본 Petstore URL 비활성화
+    operations-sorter: method # API 목록을 HTTP Method 순서로 정렬
+    display-request-duration: true # 요청 보냈을 때 걸린 시간 표시 (디버깅용)

--- a/src/test/java/org/sopt/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/sopt/member/controller/MemberControllerTest.java
@@ -1,0 +1,87 @@
+package org.sopt.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sopt.global.config.security.SecurityConfig;
+import org.sopt.global.jwt.JwtAuthenticationFilter;
+import org.sopt.member.dto.request.MemberCreateRequest;
+import org.sopt.member.dto.response.MemberResponse;
+import org.sopt.member.entity.Gender;
+import org.sopt.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = MemberController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = {
+                                SecurityConfig.class,
+                                JwtAuthenticationFilter.class
+                        }
+                )
+        }
+)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("MemberController 테스트")
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+
+    @DisplayName("회원 가입 요청 시 201 Created를 반환한다")
+    @Test
+    void createMember() throws Exception {
+        // given
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test",
+                "2001-12-01",
+                "test@example.com",
+                Gender.MALE,
+                "1234"
+        );
+
+        MemberResponse response = new MemberResponse(
+                1L,
+                "test",
+                "2001-12-01",
+                "test@example.com",
+                Gender.MALE
+        );
+
+        when(memberService.join(any(MemberCreateRequest.class)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다"))
+                .andExpect(jsonPath("$.data.name").value("test"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"));
+    }
+
+}

--- a/src/test/java/org/sopt/member/service/MemberServiceTest.java
+++ b/src/test/java/org/sopt/member/service/MemberServiceTest.java
@@ -1,0 +1,1 @@
+import org.sopt.member.repository.MemberRepository;

--- a/src/test/java/org/sopt/member/service/MemberServiceTest.java
+++ b/src/test/java/org/sopt/member/service/MemberServiceTest.java
@@ -1,1 +1,181 @@
+package org.sopt.member.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.member.dto.request.MemberCreateRequest;
+import org.sopt.member.dto.response.MemberResponse;
+import org.sopt.member.entity.Gender;
+import org.sopt.member.entity.Member;
+import org.sopt.member.exception.MemberException;
 import org.sopt.member.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+//  Mockito 사용 준비
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberService 단위 테스트")
+class MemberServiceTest {
+
+    // 가짜 객체 생성
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    // MemberService에 위 Mock들 자동 주입
+    @InjectMocks
+    private MemberService memberService;
+
+    @DisplayName("이메일 중복이 없으면 회원가입에 성공한다.")
+    @Test
+    void joinSuccess() {
+        // given 준비
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test",
+                "2001-12-01",
+                "test@example.com",
+                Gender.MALE,
+                "1234"
+        );
+        // 이메일 중복 없다고 가정
+        when(memberRepository.existsByEmail("test@example.com"))
+                .thenReturn(false);
+        // 비밀번호 암호화 시
+        when(passwordEncoder.encode("1234"))
+                .thenReturn("encoded_password_1234");
+        when(memberRepository.save(any(Member.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when 실행
+        MemberResponse response = memberService.join(request);
+
+        // then 검증
+        assertThat(response).isNotNull();
+        assertThat(response)
+                .extracting("name","email")
+                .containsExactly("test","test@example.com");
+    }
+
+    @DisplayName("미성년자가 회원가입을 시도하면 예외가 발생한다.")
+    @Test
+    void joinFailWithUnderAge() {
+        // given 준비
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test",
+                "2010-10-10",
+                "test@example.com",
+                Gender.FEMALE,
+                "1234"
+        );
+
+        when(memberRepository.existsByEmail("test@example.com"))
+                .thenReturn(false);
+
+        when(passwordEncoder.encode("1234"))
+                .thenReturn("encoded_password_1234");
+
+        // when & then 검증
+        assertThatThrownBy(() -> memberService.join(request))
+                .isInstanceOf(MemberException.class);
+    }
+
+    @DisplayName("중복된 이메일로 회원가입을 시도하면 예외가 발생한다")
+    @Test
+    void joinFailWithDuplicateEmail() {
+        // given 준비
+        MemberCreateRequest request = new MemberCreateRequest(
+                "test",
+                "2001-12-01",
+                "test@example.com",
+                Gender.MALE,
+                "1234"
+        );
+        when(memberRepository.existsByEmail("test@example.com"))
+                .thenReturn(true);
+
+        // when & then 검증
+        assertThatThrownBy(() -> memberService.join(request))
+                .isInstanceOf(MemberException.class);
+    }
+
+    @DisplayName("회원 ID로 회원을 조회할 수 있다")
+    @Test
+        void findMemberSuccess() {
+        // given 준비
+        Member member = createTestMember();
+
+        when(memberRepository.findById(1L))
+                .thenReturn(Optional.of(member));
+
+        // when 실행
+        MemberResponse response = memberService.findOne(member.getId());
+
+        // then 검증
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("test");
+    }
+
+    @DisplayName("존재하지 않는 회원 ID로 조회하면 예외가 발생한다")
+    @Test
+    void findMemberFailWithNotFound() {
+        // given 준비
+        when(memberRepository.findById(999L))
+                .thenReturn(Optional.empty());
+
+        // when & then 검증
+        assertThatThrownBy(() -> memberService.findOne(999L))
+                .isInstanceOf(MemberException.class);
+    }
+
+    @DisplayName("회원 ID로 회원을 삭제할 수 있다")
+    @Test
+    void deleteMemberSuccess() {
+        // given 준비
+        Member member = createTestMember();
+
+        when(memberRepository.findById(1L))
+                .thenReturn(Optional.of(member));
+
+        // when 실행
+        memberService.deleteMember(1L);
+
+        // then 검증
+        // 메서드가 제대로 호출되었는지 검증
+        verify(memberRepository).deleteById(1L);
+    }
+
+    @DisplayName("존재하지 않는 회원 ID로 삭제하면 예외가 발생한다")
+    @Test
+    void deleteMemberFailWithNotFound() {
+        // given 준비
+        when(memberRepository.findById(999L))
+                .thenReturn(Optional.empty());
+
+        // when & then 검증
+        assertThatThrownBy(() -> memberService.deleteMember(999L))
+                .isInstanceOf(MemberException.class);
+    }
+
+    private Member createTestMember() {
+        return Member.builder()
+                .id(1L)
+                .name("test")
+                .birth("2001-12-01")
+                .email("test@example.com")
+                .gender(Gender.MALE)
+                .password("encoded_password")
+                .build();
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 댓글 기능 구현

<br>

### 선택과제
- [x] 캐싱 성능 최적화
- [ ] 대용량 데이터 처리
- [x] 인프라 설계 시각화
- [ ] 테스트 코드 도입

<br>

### **구현한 내용에 대해서 설명해주세요**

1. 엔티티 및 DTO 검증
- `@Column(length = 300)`을 통해 DB 레벨에서 댓글 길이 제한 했습니다.
- `@Size(max = 300)`을 통해 DTO 레벨에서 댓글 길이 제한 했습니다.

2. 조회 전략
- 전체 조회`GET /articles` 시에 댓글 전체 내용 대신 댓글 수만 반환하여 응답 크기를 줄였습니다. 
- 상세 조회 `GET /articles/{id}` 시에 해당 게시글의 모든 댓글 정보를 포함하여 반환했습니다. 상세페이지에서 필요한 전체 정보를 제공합니다

3. 연관관계 설정
- `Comment` <-> `Member` 연관관계 매핑을 통해 댓글 작성자 정보를 볼 수 있습니다.

---
## 캐시

1. Article 전체 조회 및 상세 조회에 Redis 캐싱 도입
```java
// 설정 파일 전체 구조 요약
RedisConfig
├─ @EnableCaching          → 캐싱 활성화
├─ ObjectMapper            → JSON 변환 설정
├─ RedisSerializer         → 직렬화 방식 (JSON)
├─ RedisCacheConfiguration → 기본 캐시 설정
└─ CacheManager           → 캐시별 TTL 관리
```
- 아티클 작성, 댓글 작성, 수정, 삭제 시 캐시 무효화되게 구현 했습니다.

<img width="1716" height="666" alt="image" src="https://github.com/user-attachments/assets/bab679eb-7405-4d07-80cf-92e3b03ee51e" />
캐시 전

<img width="1752" height="662" alt="image" src="https://github.com/user-attachments/assets/fecb60fe-9705-462c-a9c6-8fb9c89b10dd" />
Redis 캐시 적용 후

## 대용량 데이터 

<img width="1462" height="724" alt="image" src="https://github.com/user-attachments/assets/7c4a2775-6095-462a-9711-dcd28ce351cb" />
<img width="2138" height="720" alt="image" src="https://github.com/user-attachments/assets/cd21123e-2367-48c1-9324-d14fd54a7fe4" />

- 인덱스 사용했을 때
    - rows: 139개 읽음 (1.4%)
    - type: range → B-Tree에서 BETWEEN 범위만 탐색
- 인덱스 사용하지 않았을 때
    - rows: 9,978개 읽음 (전체 스캔)
    - type: ALL → 모든 행을 순차적으로 읽음
- Selectivity 분석
    - 조회 건수 / 전체 건수 = 139 / 10,000 = 1.39% → 매우 좋음
    
article 데이터를 약 10,000개 정도 넣고 테스트를 해봤는데, 실행 속도는 차이가 안나서 Selectivity기반으로 판단했습니다.

실행시간이 별로 차이나지 않은 이유가 궁금해서 찾아보았는데
- MySQL Buffer Pool 캐싱
    - MySQL은 자주 사용하는 데이터를 메모리에 캐싱함
- 데이터 크기가 작음
    - 현재 데이터 크기가 그렇게 큰 게 아니라(1만개 정도면 크다 생각했습니다) 전체 테이블이 메모리에 올라감

이런 요인이 있다고 합니다! 현재 데이터 크기가 그리 크지 않아서 이렇게 되는 것 같긴 합니다. 

---
## 인프라 구조도
<img width="2015" height="963" alt="인프라 시각화" src="https://github.com/user-attachments/assets/8779e1eb-bf1f-4d90-82d1-ff6ad06b080f" />

다중 서버 운영은 아직 먼 얘기 같아서 단일 서버로 구성 했습니다. VPC 안에 Public, Private 나누고 Nginx와 스프링 서버를 도커를 활용하여 띄웁니다. 현재 스프링 서버가 하나인데 깜빡하고 하나만 그렸습니다. Blue, Green으로 나눠 무중단 배포까지 적용하면 좋을 것 같습니다.

다중 서버 운영시 앞단에 ALB를 두어 트래픽 분산하면 좋을 것 같습니다.

---

## 테스트
1. MemberService 단위 테스트 도입
현재 구현되어 있는 MemberService들의 메서드 단위테스트를 진행했습니다. 실패, 성공했을 경우를 나눠서 했습니다.
<br>

---

### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

1. Redis 적용 중에 캐싱은 정상적으로 되지만 2번 조회 시 서버오류가 계속 떴습니다. Redis에서 꺼낼 때 역직렬화 문제인 것 같은데 `RedisConfig` 파일에서         
`mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING;` 이 부분을 EVERYTHING으로 설정 시 임시적으로 해결은 되지만 EVERYTHING이 deprecated 예정이라고 해서 해결중입니다.. 혹시 관련 문제 있거나 아시는 분 도와주시면 감사하겠습니다.
<br>

2. 테스트코드 도입시에 AssertJ와 JUnit 두 가지 선택지가 있었는데요, 찾아보니까 그냥 AssertJ를 사용하라고 합니다. AssertJ가 메서드 체이닝도 되고 여러모로 장점이라고 하네요! 
<img width="808" height="317" alt="image" src="https://github.com/user-attachments/assets/3f9ba7f6-d50d-4cf0-8191-354e4378f096" />

---
### **키워드 과제 정리내용**


<br>

---

## 🚨 참고 사항
캐시관련, 인덱스관련 시간 차 등등 무수한 팁들 공유 부탁드립니다.

테스트관련
현재 service단에서 단위 테스트만 진행 했지만 컨트롤러 테스트 -> 레포지토리 테스트 -> 통합테스트 순으로 이어나갈 예정입니다.
